### PR TITLE
Fix `npm run start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "npx eslint . --ext .mjs --max-warnings=0",
     "lint:fix": "npx eslint . --ext .mjs --fix --max-warnings=0",
     "serve": "lite-server",
-    "start": "npm run serve & npm run watch",
+    "start": "npm run build & npm run serve & npm run watch",
     "watch": "nodemon --ext mjs,html,json,css --exec npm run build"
   },
   "lint-staged": {


### PR DESCRIPTION
Previously the served HTML page would throw an error if `npm run build` hadn't been run to generate an initial script.js file. This commit fixes that issue by running the build command as part of the start command.